### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
cleardb 의 기본 mysql 버전이 '5.6' 으로 프로젝트에서 사용하는 mysql 버전 '8.0'과 다르므로
 ('5.6'버전에서는 'article_comment.content' 인덱스 사이즈가 너무 큼
대안으로 'jawsdb'를 사용 
이를 이용해 환경변수를 다시 작업함.

This fixes #44 
*https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options *https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup