### PR TITLE
[고도화] 보안 기능 고도화 - 환경변수의 사용

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,9 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/board
-    username: chris
-    password: 1234
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -30,8 +30,6 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${KAKAO_OAUTH_CLIENT_ID}
-            client-secret: ${KAKAO_OAUTH_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
             client-authentication-method: POST


### PR DESCRIPTION
이 PR은 `application.yaml`에 노출되어 있던 각종 민감 정보를 변수로 치환하여 보안에 문제되지 않게끔 한다.
그러나, 이전 커밋 노드에서 조회하면 여전히 노출된 값을 볼 수 있으므로
근본적인 해결을 위해서는 이 저장소를 삭제하고 새로 만드는 수 밖에 없을 듯 하다.
일단 공부를 하는 의미에서 이 PR을 적용한다.

This closes #73 